### PR TITLE
make template work with azure to rake regex.

### DIFF
--- a/azurerm/marketplace-azure/cc16-on-ubuntu/createUiDefinition.json
+++ b/azurerm/marketplace-azure/cc16-on-ubuntu/createUiDefinition.json
@@ -143,7 +143,7 @@
             "defaultValue": "",
             "constraints": {
               "required": true,
-              "regex": "/.+@.+/",
+              "regex": ".+@.+",
               "validationMessage": "Owner email is required"
             },
             "options": { }


### PR DESCRIPTION
Basically rather than having you put in the full regex azure is modifying the regex that you put in so /something/ turns into //something// this not intuitive for anyone who uses regex on any sort of regular basis...