### PR TITLE
enable other types of storage account types in templates.

### DIFF
--- a/azurerm/marketplace-azure/cc16-on-ubuntu/mainTemplate.json
+++ b/azurerm/marketplace-azure/cc16-on-ubuntu/mainTemplate.json
@@ -116,7 +116,10 @@
       },
       "defaultValue": "Standard_LRS",
       "allowedValues": [
-        "Standard_LRS"
+        "Standard_LRS",
+        "Standard_GRS",
+        "Standard_RAGRS",
+        "Standard_ZRS"
       ]
     },
     "existingStorageAccountRG": {


### PR DESCRIPTION
since we are allowing a user to specify in createui we should make sure those values are valid.